### PR TITLE
Fix function resolving in IDL

### DIFF
--- a/IDL/bdtri.pro
+++ b/IDL/bdtri.pro
@@ -64,6 +64,13 @@
 ;       IBETA       - IDL >4.0
 ;       BISECTION   - IDL >4.0
 
+function incbi, x
+    compile_opt idl2, hidden
+    common incbi_parms
+    
+	return, ibeta(b-a, a+1, x) - p
+end
+
 function bdtri, k, n, y
     compile_opt idl2
     
@@ -94,11 +101,4 @@ function bdtri, k, n, y
 	p = y
 
     return, 1 - bisection(0.5, 'incbi', itmax=200, radius=0.5, tol=1e-7)
-end
-
-function incbi, x
-    compile_opt idl2, hidden
-    common incbi_parms
-    
-	return, ibeta(b-a, a+1, x) - p
 end

--- a/IDL/binomial_limits.pro
+++ b/IDL/binomial_limits.pro
@@ -76,9 +76,6 @@
 ;       BDTRI   - IDL >5.3
 
 function binomial_limits, nsuccess, ntotal, cl, sigma=sigma
-	; Resolve the 'incbi' routine in bdtri.pro so that 'bisection'
-	; can find it with call_function
-	resolve_routine, 'bdtri', /is_function
 	
 	; Set CL = 1 sigma by default
     if ~keyword_set(cl) then begin

--- a/IDL/pdtri.pro
+++ b/IDL/pdtri.pro
@@ -67,6 +67,13 @@
 ;       IGAMMA      - IDL >4.0
 ;       BISECTION   - IDL >4.0
 
+function igami, x
+    compile_opt idl2, hidden
+    common igami_parms
+    
+	return, 1 - igamma(a+1, x, /double) - p
+end
+
 function pdtri, k, y
     ; check the domain
     if k lt 0 then begin
@@ -91,11 +98,4 @@ function pdtri, k, y
     x0 = a * (t^3)
 
     return, bisection(x0, 'igami', itmax=200, radius=x0, tol=1e-7)
-end
-
-function igami, x
-    compile_opt idl2, hidden
-    common igami_parms
-    
-	return, 1 - igamma(a+1, x, /double) - p
 end

--- a/IDL/poisson_limits.pro
+++ b/IDL/poisson_limits.pro
@@ -72,9 +72,6 @@
 ;       PDTRI   - IDL >5.3
 
 function poisson_limits, k, cl, sigma=sigma
-    ; Resolve the 'igami' routine in pdtri.pro so that 'bisection'
-	; can find it with call_function
-	resolve_routine, 'pdtri', /is_function
 
     ; Set CL = 1 sigma by default
     if ~keyword_set(cl) then begin


### PR DESCRIPTION
The existing resolve_routine calls in bdtri.pro and pdtri.pro were not
working and not necessary. Remove those calls, and put the functions
that needed resolving at the front of their files, so they are
automatically compiled when the file's main function is called.

The existing resolve_routine calls could have been fixed by adding the /COMPILE_FULL_FILE keyword per http://www.harrisgeospatial.com/docs/RESOLVE_ROUTINE.html, but the solution of putting the troublesome functions above the files' namesake routines works better.

I have tested this, and it works in IDL (8.5.1).

Thanks for this library, glad to contribute!
-- Nathaniel