### PR TITLE
Fix function resolving in IDL

### DIFF
--- a/IDL/bdtri.pro
+++ b/IDL/bdtri.pro
@@ -64,6 +64,13 @@
 ;       IBETA       - IDL >4.0
 ;       BISECTION   - IDL >4.0
 
+function incbi, x
+    compile_opt idl2, hidden
+    common incbi_parms
+    
+	return, ibeta(b-a, a+1, x) - p
+end
+
 function bdtri, k, n, y
     compile_opt idl2
     
@@ -94,11 +101,4 @@ function bdtri, k, n, y
 	p = y
 
     return, 1 - bisection(0.5, 'incbi', itmax=200, radius=0.5, tol=1e-7)
-end
-
-function incbi, x
-    compile_opt idl2, hidden
-    common incbi_parms
-    
-	return, ibeta(b-a, a+1, x) - p
 end

--- a/IDL/bdtri.pro
+++ b/IDL/bdtri.pro
@@ -66,7 +66,7 @@
 
 function incbi, x
     compile_opt idl2, hidden
-    common incbi_parms
+    common incbi_parms, a, b, p
     
 	return, ibeta(b-a, a+1, x) - p
 end
@@ -95,7 +95,7 @@ function bdtri, k, n, y
         message, 'bdtri domain error: y must be in the interval [0,1]'
     endif
     
-	common incbi_parms, a, b, p
+	common incbi_parms
 	a = k
 	b = n
 	p = y

--- a/IDL/binomial_limits.pro
+++ b/IDL/binomial_limits.pro
@@ -76,9 +76,6 @@
 ;       BDTRI   - IDL >5.3
 
 function binomial_limits, nsuccess, ntotal, cl, sigma=sigma
-	; Resolve the 'incbi' routine in bdtri.pro so that 'bisection'
-	; can find it with call_function
-	resolve_routine, 'bdtri', /is_function
 	
 	; Set CL = 1 sigma by default
     if ~keyword_set(cl) then begin

--- a/IDL/pdtri.pro
+++ b/IDL/pdtri.pro
@@ -67,6 +67,13 @@
 ;       IGAMMA      - IDL >4.0
 ;       BISECTION   - IDL >4.0
 
+function igami, x
+    compile_opt idl2, hidden
+    common igami_parms
+    
+	return, 1 - igamma(a+1, x, /double) - p
+end
+
 function pdtri, k, y
     ; check the domain
     if k lt 0 then begin
@@ -91,11 +98,4 @@ function pdtri, k, y
     x0 = a * (t^3)
 
     return, bisection(x0, 'igami', itmax=200, radius=x0, tol=1e-7)
-end
-
-function igami, x
-    compile_opt idl2, hidden
-    common igami_parms
-    
-	return, 1 - igamma(a+1, x, /double) - p
 end

--- a/IDL/pdtri.pro
+++ b/IDL/pdtri.pro
@@ -69,7 +69,7 @@
 
 function igami, x
     compile_opt idl2, hidden
-    common igami_parms
+    common igami_parms, a, p
     
 	return, 1 - igamma(a+1, x, /double) - p
 end
@@ -88,7 +88,7 @@ function pdtri, k, y
         message, 'pdtri domain error: y must be in the interval [0, 1)'
     endif
     
-	common igami_parms, a, p
+	common igami_parms
 	a = k
 	p = y
     

--- a/IDL/poisson_limits.pro
+++ b/IDL/poisson_limits.pro
@@ -72,9 +72,6 @@
 ;       PDTRI   - IDL >5.3
 
 function poisson_limits, k, cl, sigma=sigma
-    ; Resolve the 'igami' routine in pdtri.pro so that 'bisection'
-	; can find it with call_function
-	resolve_routine, 'pdtri', /is_function
 
     ; Set CL = 1 sigma by default
     if ~keyword_set(cl) then begin


### PR DESCRIPTION
    The existing resolve_routine calls in bdtri.pro and pdtri.pro were not
    working and not necessary. Remove those calls, and put the functions
    that needed resolving at the front of their files, so they are
    automatically compiled when the file's main function is called. Update
    common block specifications to work with the new order.

(resolve_routine calls didn't work without /COMPILE_FULL_FILE keyword, because
"When compiling a file to find a specified routine, IDL normally stops compiling when the desired routine (Name) is found. If set, COMPILE_FULL_FILE compiles the entire file."
See http://www.harrisgeospatial.com/docs/RESOLVE_ROUTINE.html )

Changing the order of the functions so the last one in the file is the one whose name matches the filename, eliminates the need for resolve_routines call entirely.

I appreciate this library, glad to contribute.
-- Nathaniel